### PR TITLE
User Can't Like products without login

### DIFF
--- a/client/src/Components/Product/ProductPreview.jsx
+++ b/client/src/Components/Product/ProductPreview.jsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { Link } from "react-router-dom";
 import { Grid, Button, Icon, Image, Header } from "semantic-ui-react";
+import {useNavigate} from "react-router-dom";
 
 const ProductPreview = ({ id, heading, description, image, likes }) => {
   let linkStyle = {
@@ -24,17 +25,24 @@ const ProductPreview = ({ id, heading, description, image, likes }) => {
   };
   const [currentLikes, setCurrentLikes] = React.useState(likes);
   const [hover, setHover] = React.useState(false);
+  let history = useNavigate();
 
   async function changeLikes(e) {
-    const response = await fetch('http://localhost:5000/changeLikes',{
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json'
-      },
-      body: JSON.stringify({id:id,likes:currentLikes})
-    })
-    const res = await response.json();
-    setCurrentLikes(res.likes);
+    const JWTtoken = localStorage.getItem('token');
+    if(JWTtoken) {
+      const response = await fetch('http://localhost:5000/changeLikes',{
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'auth-token': localStorage.getItem('token')
+        },
+        body: JSON.stringify({id:id,likes:currentLikes,JWTtoken:JWTtoken})
+      })
+      const res = await response.json();
+      setCurrentLikes(res.likes);
+    }else{
+      history('/login');
+    }
   }
 
   return (

--- a/middleware/auth.js
+++ b/middleware/auth.js
@@ -4,8 +4,8 @@ const User=require('../model/User')
 const verifyToken=async (req,res,next)=>{
     try{
         const token=req.header('auth-token')
-       // console.log('In the middleware')
-       // console.log(token)
+       console.log('In the middleware')
+       console.log(token)
         const decoded=jwt.verify(token,'hello')
         const user= await User.findOne({_id:decoded._id})
         if(!user){

--- a/routes/project.js
+++ b/routes/project.js
@@ -68,7 +68,7 @@ router.delete('/deleteProject/:id',verifyToken,async (req,res)=>{
   }
 })
 
-router.post('/changeLikes',async (req,res)=>{
+router.post('/changeLikes',verifyToken,async (req,res)=>{
   try{
     const project = await Project.findOne({_id:req.body.id});
     project.likes = req.body.likes+1;


### PR DESCRIPTION
Closes #175 

User can't like products without login.
Steps followed.
1.First checked if user is logged in or not.
2. If NO, then he is redirected to the '/login' route.
3. If YES, then token inside localstorage is passes in headers and then middleware is used to know if user is genuine or not.

## Screenshots
If user is not logged in then on liking the produt,

![1](https://user-images.githubusercontent.com/77476772/170830257-e36d716a-7b3b-4a2a-8173-407e0d0e3e70.png)

![2](https://user-images.githubusercontent.com/77476772/170830269-9eca2349-a63d-483a-ad32-f887379b8d7c.png)


hope you liked the work :)
